### PR TITLE
added testng.xml and modified pom for running tests locally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.12.4</version>
+              <configuration>
+                 <suiteXmlFiles> <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile></suiteXmlFiles>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+  <suite name="Default Suite">
+      <test name="test">
+          <classes>
+              <class name="Tests.AlertPageTest"/> <!--Package.ClassName-->
+          </classes>
+      </test>
+  </suite>


### PR DESCRIPTION
Issue

  When uploading appium testNG test package to aws Device Farm it is required to have the testng.xml file in the root of the jar. This is not clearly documented and this article should help with resolving and preventing future issues customers may face

Short Description

  This article describes how to include the testng.xml files in the root of the jar file created using a maven command from awslabs github project.
Resolution

To exemplify using the testng.xml file we'll use the sample appium java project [1]and the sample android project [2]from awslabs github page.

  - After downloading or cloning the appium java testng sample project, and extracting it if necessary, change the active directory to that project.

  cd aws-device-farm-appium-tests-for-sample-app/

  - Then we'll create the /src/test/resources directory to take advantage of the super pom default configuration:  

mkdir src/test/resources

Content added to the src/test/resources directory gets added because of this tag in the super pom which is configured to added all files to the jar that are in the resources directory [3] . To view the super pom of the project run this command: 

mvn help:effective-pom

Alternatively, we can implement the testResources tags in the pom.xml to explictly reference another directory besides src/test/resources as in this maven doc:

https://maven.apache.org/pom.html#Resources 

I then created the testng.xml file in the src/test/resources directory and added this content to it to only run the AlertPageTest class:

  <?xml version="1.0" encoding="UTF-8"?>
  <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
  <suite name="Default Suite">
      <test name="test">
          <classes>
              <class name="Tests.AlertPageTest"/> <!--Package.ClassName-->
          </classes>
      </test>
  </suite>

  - Then I modified the pom.xml to include the surefire plugin to reference this testng.xml file which is necessary for running the tests locally as testng tests but optional if the project is just for Device Farm [4] :

<plugin> 
    <groupId>org.apache.maven.plugins</groupId> 
    <artifactId>maven-surefire-plugin</artifactId> 
    <version>2.12.4</version> 
    <configuration>
       <suiteXmlFiles> <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile></suiteXmlFiles>
    </configuration>
</plugin>
        

   - Once this is done I then deleted the contents of the target directory and packaged the tests using this maven command:

mvn clean package -DskipTests=true

   This created the zip-with-dependencies.zip file in the target directory with the two jar files. I extracted the jar to verify that the test.xml was in the root (see screenshot targetDirectoryBeforeExtraction.png and targetDirectoryAfterExtraction.png) using this command [5]: 

jar xf nameOfTheProjectFromPom-1.0-SNAPSHOT-tests.jar